### PR TITLE
Mark Encoder as Send + Sync to enable multithreaded use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,6 +622,11 @@ impl Drop for Encoder {
     }
 }
 
+/// According to LAME 3.99.5 HACKING, it is thread-safe.
+unsafe impl Send for Encoder {}
+/// According to LAME 3.99.5 HACKING, it is thread-safe.
+unsafe impl Sync for Encoder {}
+
 ///Creates default encoder with 192kbps bitrate and best possible quality.
 pub fn encoder() -> Result<Encoder, BuildError> {
     match Builder::new() {


### PR DESCRIPTION
To quote LAME 3.99.5 HACKING:
THREADSAFE:

> Lame should now be thread safe and re-entrant. 
> The only problem seems to be some OS's allocate small stacks (< 128K) to threads launched by applictions, and this is not enough for LAME.  Fix is to increase the stack space, or move some of our automatic variables onto the heap with by using bug-prove malloc()'s and free().

I have tested this in a streaming setup and it does seem to work, although I didn't test thorougly.