### PR TITLE
Improve `Builder` ergonomics with the faillible `with_*` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,22 @@
 //!    comment: b"Just my comment",
 //!});
 //!let mut mp3_encoder = mp3_encoder.build().expect("To initialize LAME encoder");
+//! 
+//!//You can also use the builder pattern:
+//! let mut mp3_encoder = Builder::new().expect("Create LAME builder")
+//!     .with_num_channels(2).expect("set channels")
+//!     .with_sample_rate(44_100).expect("set sample rate")
+//!     .with_brate(mp3lame_encoder::Bitrate::Kbps192).expect("set brate")
+//!     .with_quality(mp3lame_encoder::Quality::Best).expect("set quality")
+//!     .with_id3_tag(Id3Tag {
+//!         title: b"My title",
+//!         artist: &[],
+//!         album: b"My album",
+//!         album_art: &[],
+//!         year: b"Current year",
+//!         comment: b"Just my comment",
+//!      }).expect("set tags")
+//!     .build().expect("To initialize LAME encoder");
 //!
 //!//use actual PCM data
 //!let input = DualPcm {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ impl Builder {
     #[inline]
     ///Sets sample rate.
     ///
-    ///Defaults to 44_100
+    ///Defaults to 44_100.
     ///
     ///Returns whether it is supported or not.
     pub fn set_sample_rate(&mut self, rate: u32) -> Result<(), BuildError> {
@@ -385,9 +385,20 @@ impl Builder {
     }
 
     #[inline]
-    ///Sets sample rate.
+    ///Sets sample rate using the builder pattern.
+    /// 
+    ///Defaults to 44_100.
+    /// 
+    ///Returns an error if it is not supported.
+    pub fn with_sample_rate(mut self, rate: u32) -> Result<Self, BuildError> {
+        self.set_sample_rate(rate)?;
+        Ok(self)
+    }
+
+    #[inline]
+    ///Sets number of channels.
     ///
-    ///Defaults to 2
+    ///Defaults to 2.
     ///
     ///Returns whether it is supported or not.
     pub fn set_num_channels(&mut self, num: u8) -> Result<(), BuildError> {
@@ -396,6 +407,17 @@ impl Builder {
         };
 
         BuildError::from_c_int(res)
+    }
+
+    #[inline]
+    ///Sets sample rate using the builder pattern.
+    ///
+    ///Defaults to 2.
+    ///
+    ///Returns an error if it is not supported.
+    pub fn with_num_channels(mut self, num: u8) -> Result<Self, BuildError> {
+        self.set_num_channels(num)?;
+        Ok(self)
     }
 
     #[inline]
@@ -413,6 +435,17 @@ impl Builder {
     }
 
     #[inline]
+    ///Sets bitrate (as kbps) using the builder pattern.
+    ///
+    ///Defaults to compression ratio of 11.
+    ///
+    ///Returns an error if it is not supported.
+    pub fn with_brate(mut self, brate: Bitrate) -> Result<Self, BuildError> {
+        self.set_brate(brate)?;
+        Ok(self)
+    }
+
+    #[inline]
     ///Sets MPEG mode.
     ///
     ///Default is picked by LAME depending on compression ration and input channels.
@@ -424,6 +457,17 @@ impl Builder {
         };
 
         BuildError::from_c_int(res)
+    }
+
+    #[inline]
+    ///Sets MPEG mode using the builder pattern.
+    ///
+    ///Default is picked by LAME depending on compression ration and input channels.
+    ///
+    ///Returns an error if it is not supported.
+    pub fn with_mode(mut self, mode: Mode) -> Result<Self, BuildError> {
+        self.set_mode(mode)?;
+        Ok(self)
     }
 
     #[inline]
@@ -441,6 +485,17 @@ impl Builder {
     }
 
     #[inline]
+    ///Sets quality using the builder pattern.
+    ///
+    ///Default is good one(5)
+    ///
+    ///Returns an error if it is not supported.
+    pub fn with_quality(mut self, quality: Quality) -> Result<Self, BuildError> {
+        self.set_quality(quality)?;
+        Ok(self)
+    }
+
+    #[inline]
     ///Sets VBR quality.
     ///
     ///Returns whether it is supported or not.
@@ -452,11 +507,19 @@ impl Builder {
         BuildError::from_c_int(res)
     }
 
+    #[inline]
+    ///Sets VBR quality using the builder pattern.
+    /// 
+    ///Returns an error if it is not supported.
+    pub fn with_vbr_quality(mut self, quality: Quality) -> Result<Self, BuildError> {
+        self.set_vbr_quality(quality)?;
+        Ok(self)
+    }
 
     #[inline]
     ///Sets whether to write VBR tag.
     ///
-    ///Default is true
+    ///Default is true.
     ///
     ///Returns whether it is supported or not.
     pub fn set_to_write_vbr_tag(&mut self, value: bool) -> Result<(), BuildError> {
@@ -468,7 +531,18 @@ impl Builder {
     }
 
     #[inline]
-    ///Sets VBR mode
+    ///Sets whether to write VBR tag using the builder pattern.
+    ///
+    ///Default is true.
+    ///
+    ///Returns an error if it is not supported.
+    pub fn with_to_write_vbr_tag(mut self, value: bool) -> Result<Self, BuildError> {
+        self.set_to_write_vbr_tag(value)?;
+        Ok(self)
+    }
+
+    #[inline]
+    ///Sets VBR mode.
     ///
     ///Default is off (i.e. CBR)
     ///
@@ -479,6 +553,17 @@ impl Builder {
         };
 
         BuildError::from_c_int(res)
+    }
+
+    #[inline]
+    ///Sets VBR mode using the bulder pattern.
+    /// 
+    ///Default is off (i.e. CBR)
+    /// 
+    ///Returns an error if it is not supported.
+    pub fn with_vbr_mode(mut self, value: VbrMode) -> Result<Self, BuildError> {
+        self.set_vbr_mode(value)?;
+        Ok(self)
     }
 
     #[inline]
@@ -546,6 +631,17 @@ impl Builder {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    ///Sets id3tag tag using the builder pattern.
+    ///
+    ///If [FlushGap](FlushGap) is used, then `v1` will not be added.
+    /// 
+    ///Returns an error if it is not supported.
+    pub fn with_id3_tag(mut self, value: Id3Tag<'_>) -> Result<Self, Id3TagError> {
+        self.set_id3_tag(value)?;
+        Ok(self)
     }
 
     #[inline]

--- a/tests/mp3.rs
+++ b/tests/mp3.rs
@@ -130,3 +130,128 @@ fn should_decode_and_encode() {
     let _ = mp3_encoder.flush_to_vec::<FlushNoGap>(&mut mp3_out_buffer).expect("to flush");
     fs::write(NEW_FILE, &mp3_out_buffer).expect("write file")
 }
+
+#[test]
+fn should_decode_and_encode_using_builder_pattern() {
+    const FILE: &str = "tests/Bell3.ogg";
+    const NEW_FILE: &str = "tests/Bell3_with_builder_encoded.mp3";
+
+    let file = fs::File::open(FILE).expect("open FILE");
+    let file = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    hint.with_extension("ogg");
+
+    let format_opts = Default::default();
+    let metadata_opts = Default::default();
+    let decoder_opts = Default::default();
+
+    // Probe the media source stream for a format.
+    let probed = symphonia::default::get_probe().format(&hint, file, &format_opts, &metadata_opts).expect("To probe mp3 file");
+    // Get the format reader yielded by the probe operation.
+    let mut format = probed.format;
+    let track = format.default_track().expect("Get default track");
+    let mut decoder = symphonia::default::get_codecs().make(&track.codec_params, &decoder_opts).unwrap();
+
+    // Store the track identifier, we'll use it to filter packets.
+    let track_id = track.id;
+
+    let first_packet = loop {
+        let packet = format.next_packet().expect("to get packet");
+        if packet.track_id() != track_id {
+            continue
+        }
+        break packet;
+    };
+
+    let audio_buf = decoder.decode(&first_packet).expect("To decode first packet");
+    let spec = *audio_buf.spec();
+    let spec_channels = spec.channels.count();
+
+    let mut mp3_out_buffer = Vec::new();
+
+    // Build the encoder using builder-like ernomonics
+    let mut mp3_encoder = Builder::new().expect("Create LAME builder")
+        .with_num_channels(spec_channels as u8).expect("set channels")
+        .with_sample_rate(spec.rate).expect("set sample rate")
+        .with_brate(mp3lame_encoder::Birtate::Kbps192).expect("set brate")
+        .with_quality(mp3lame_encoder::Quality::Best).expect("set quality")
+        .with_id3_tag(Id3Tag {
+            title: b"Bell",
+            artist: &[],
+            album: b"Test",
+            album_art: ALBUM_ART,
+            year: b"2022",
+            comment: b"Just some test shit",
+        }).expect("Id3 tag")
+        .build().expect("To initialize LAME encoder");
+
+
+    mp3_out_buffer.reserve(MAX_ALBUM_ART_SIZE);
+
+    let mut samples_num = audio_buf.frames();
+    match audio_buf {
+        AudioBufferRef::F32(audio_buf) => {
+            let planes = audio_buf.planes();
+            let planes = planes.planes();
+            assert_eq!(planes.len(), 1);
+            let input = MonoPcm(planes[0]);
+            assert_eq!(samples_num, input.0.len());
+            mp3_out_buffer.reserve(mp3lame_encoder::max_required_buffer_size(samples_num));
+            mp3_encoder.encode_to_vec(input, &mut mp3_out_buffer).expect("To encode");
+        }
+        AudioBufferRef::F64(audio_buf) => {
+            let planes = audio_buf.planes();
+            let planes = planes.planes();
+            assert_eq!(planes.len(), 1);
+            let input = MonoPcm(planes[0]);
+            assert_eq!(samples_num, input.0.len());
+            mp3_out_buffer.reserve(mp3lame_encoder::max_required_buffer_size(samples_num));
+            mp3_encoder.encode_to_vec(input, &mut mp3_out_buffer).expect("To encode");
+        }
+        _ => panic!("Unexpected"),
+    }
+
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(SymError::IoError(error)) => match error.kind() {
+                io::ErrorKind::UnexpectedEof => break,
+                _ => panic!("Unexpected IO error: {error}"),
+            },
+            Err(error) => panic!("Unexpected error reading packets: {error}"),
+        };
+
+        if packet.track_id() != track_id {
+            continue
+        }
+
+        let audio_buf = decoder.decode(&packet).expect("To decode first packet");
+
+        samples_num = audio_buf.frames();
+
+        match audio_buf {
+            AudioBufferRef::F32(audio_buf) => {
+                let planes = audio_buf.planes();
+                let planes = planes.planes();
+                assert_eq!(planes.len(), 1);
+                let input = MonoPcm(planes[0]);
+                assert_eq!(samples_num, input.0.len());
+                mp3_out_buffer.reserve(mp3lame_encoder::max_required_buffer_size(samples_num));
+                mp3_encoder.encode_to_vec(input, &mut mp3_out_buffer).expect("To encode");
+            }
+            AudioBufferRef::F64(audio_buf) => {
+                let planes = audio_buf.planes();
+                let planes = planes.planes();
+                assert_eq!(planes.len(), 2);
+                let input = MonoPcm(planes[0]);
+                assert_eq!(samples_num, input.0.len());
+                mp3_out_buffer.reserve(mp3lame_encoder::max_required_buffer_size(samples_num));
+                mp3_encoder.encode_to_vec(input, &mut mp3_out_buffer).expect("To encode");
+            }
+            _ => panic!("Unexpected"),
+        }
+    }
+
+    let _ = mp3_encoder.flush_to_vec::<FlushNoGap>(&mut mp3_out_buffer).expect("to flush");
+    fs::write(NEW_FILE, &mp3_out_buffer).expect("write file")
+}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -23,19 +23,33 @@
    ...
 }
 {
-   rust_rt_maybe_leak
-   Memcheck:Leak
-   match-leak-kinds: possible
-   fun:malloc
-   fun:*lang_start_internal*
-   fun:main
-}
-{
    symphonia_bad_static3
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc
    ...
    fun:*symphonia_format_ogg*demuxer*OggReader*symphonia_core*formats*FormatReader*try_new*
-   fun:_ZN4core3ops8function6FnOnce9call_once17h6099d6ea9fe1a731E
+   fun:*FnOnce*call_once*
+}
+{
+   symphonia_bad_static3.5
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*symphonia_format_ogg*demuxer*OggReader*
+   fun:*FnOnce*call_once*
+}
+{
+   rust_compiler_leak_error_on_panic_in_rt
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*thread*current*init_current*
+   ...
+   fun:*run_tests_console*
+   ...
+   fun:*rt*lang_start*
+   fun:*rt*lang_start_internal*
 }


### PR DESCRIPTION
Closes #7 

As mentioned by @DoumanAsh in one of the issue comments, such methods are with a `with_` prefix and they internally the respective `set_` method, returning `Self` in case the underlying operation succeeds.

I've also added a test case which is directly taken from the original test: `decode_and_encode`, but uses the newly built pattern to build the encoder.

I'm yet to update the docs but if everything seems acceptable to you, @DoumanAsh, I'll add that too. Let me know if this is not how you imagined it to be.