### PR TITLE
Add method to specify the output sample rate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,6 +388,10 @@ impl Builder {
     ///Sets output sample rate.
     ///
     ///The default `None` allows LAME to pick the best value.
+    ///The supported values are:
+    /// - MPEG1: `32_000`, `44_100` and `48_000`
+    /// - MPEG2: `16_000`, `22_050` and `24_000`
+    /// - MPEG2.5: `8_000`, `11_025` and `12_000`
     ///
     ///Returns `Ok(())` the requested value is supported and was set successfully.
     pub fn set_output_sample_rate(&mut self, rate: Option<NonZeroU32>) -> Result<(), BuildError> {
@@ -404,6 +408,10 @@ impl Builder {
     ///Sets output sample rate using the builder pattern.
     ///
     ///The default `None` allows LAME to pick the best value.
+    ///The supported values are:
+    /// - MPEG1: `32_000`, `44_100` and `48_000`
+    /// - MPEG2: `16_000`, `22_050` and `24_000`
+    /// - MPEG2.5: `8_000`, `11_025` and `12_000`
     ///
     ///Returns `Ok(())` the requested value is supported and was set successfully.
     pub fn with_output_sample_rate(mut self, rate: Option<NonZeroU32>) -> Result<Self, BuildError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ impl Builder {
     ///
     ///The default `None` allows LAME to pick the best value.
     ///
-    ///Returns whether the requested value is supported.
+    ///Returns `Ok(())` the requested value is supported and was set successfully.
     pub fn set_output_sample_rate(&mut self, rate: Option<NonZeroU32>) -> Result<(), BuildError> {
         let rate = rate.map_or(0, NonZeroU32::get).try_into().unwrap_or(libc::c_int::MAX);
 
@@ -405,7 +405,7 @@ impl Builder {
     ///
     ///The default `None` allows LAME to pick the best value.
     ///
-    ///Returns whether the requested value is supported.
+    ///Returns `Ok(())` the requested value is supported and was set successfully.
     pub fn with_output_sample_rate(mut self, rate: Option<NonZeroU32>) -> Result<Self, BuildError> {
         self.set_output_sample_rate(rate)?;
         Ok(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use mp3lame_sys as ffi;
 
 use alloc::vec::Vec;
 use core::mem::{self, MaybeUninit};
+use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
 use core::{cmp, fmt};
 
@@ -384,7 +385,34 @@ impl Builder {
     }
 
     #[inline]
-    ///Sets sample rate.
+    ///Sets output sample rate.
+    ///
+    ///The default `None` allows LAME to pick the best value.
+    ///
+    ///Returns whether the requested value is supported.
+    pub fn set_output_sample_rate(&mut self, rate: Option<NonZeroU32>) -> Result<(), BuildError> {
+        let rate = rate.map_or(0, NonZeroU32::get).try_into().unwrap_or(libc::c_int::MAX);
+
+        let res = unsafe {
+             ffi::lame_set_out_samplerate(self.ptr(), rate)
+        };
+
+        BuildError::from_c_int(res)
+    }
+
+    #[inline]
+    ///Sets output sample rate using the builder pattern.
+    ///
+    ///The default `None` allows LAME to pick the best value.
+    ///
+    ///Returns whether the requested value is supported.
+    pub fn with_output_sample_rate(mut self, rate: Option<NonZeroU32>) -> Result<Self, BuildError> {
+        self.set_output_sample_rate(rate)?;
+        Ok(self)
+    }
+
+    #[inline]
+    ///Sets input sample rate.
     ///
     ///Defaults to 44_100.
     ///
@@ -398,7 +426,7 @@ impl Builder {
     }
 
     #[inline]
-    ///Sets sample rate using the builder pattern.
+    ///Sets input sample rate using the builder pattern.
     /// 
     ///Defaults to 44_100.
     /// 


### PR DESCRIPTION
I made the function accept a `Option<NonZeroU32>`, but I would be open to replace it with a enum of the 9 accepted values.

Additionally to this change I have 3 possible options + pseudocode, that I'm unsure which one would be best for the future:
1. Do Nothing
2. Rename function and mark old one as deprecated
```rust
fn set_input_sample_rate(rate) { lame_set_in_samplerate(rate); }

#[deprecated]
fn set_sample_rate(rate) { self.set_input_sample_rate(rate); }
```
3. Make function set both sample rates. This is what FFmpeg [currently does](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD:/libavcodec/libmp3lame.c#l112). This would, however, change the behaviour of the function by probably having worse compression rates (I haven't tested this, it's just a guess) and returning errors for values that were previously accepted.
```rust
fn set_input_sample_rate(rate) { lame_set_in_samplerate(rate) }

fn set_sample_rate(rate) {
    self.set_input_sample_rate(rate);
    self.set_output_sample_rate(rate);
}
```